### PR TITLE
new version 0.3, ensure package includes data/*.otf

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include avatar_generator/data/*.otf

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='avatar-generator',
-    version='0.2',
+    version='0.3',
     author="Guillaume Subiron",
     author_email="maethor+pip@subiron.org",
     description="Generates default avatars from a given string (such as username).",


### PR DESCRIPTION
RT:  add `MANIFEST.in` , make sure that package includes data/*.otf .

refer:  https://python-packaging.readthedocs.io/en/latest/non-code-files.html

fix issue: 

https://github.com/maethor/avatar-generator/issues/3
